### PR TITLE
Add support for PHP 8.3 and Update README.md

### DIFF
--- a/8.3/Dockerfile
+++ b/8.3/Dockerfile
@@ -1,0 +1,14 @@
+FROM php:8.3
+
+LABEL "com.github.actions.name"="PHP Lint 8.3"
+LABEL "com.github.actions.description"="Run the native PHP linter"
+LABEL "com.github.actions.icon"="check"
+LABEL "com.github.actions.color"="blue"
+
+LABEL "repository"="http://github.com/dbfx/github-phplint"
+LABEL "homepage"="http://github.com/actions"
+LABEL "maintainer"="Dave B <dave@blakey.co>"
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod 555 /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/8.3/action.yml
+++ b/8.3/action.yml
@@ -1,0 +1,13 @@
+# action.yml
+name: 'PHP 8.3 Lint'
+description: 'PHP linter for PHP 8.3'
+inputs:
+  folder-to-exclude:
+    description: 'Folder to exclude'
+    required: false
+    default: '! -path "./vendor/*"'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.folder-to-exclude }}

--- a/8.3/entrypoint.sh
+++ b/8.3/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -l
+
+sh -c "! (find . -type f -name \"*.php\" $1 -exec php -l -n {} \; | grep -v \"No syntax errors detected\")"

--- a/README.md
+++ b/README.md
@@ -8,24 +8,24 @@ meant to run on multiple PHP versions.
 
 ## Getting Started
 
-Using this action can be done with the following template:
+Using this action to check for syntax / parse errors for PHP versions 7.4, 8.0, and 8.3 can be done with the following template:
 
 ```
 steps:
   - name: Checkout
-    uses: actions/checkout@v1
+    uses: actions/checkout@v4
     with:
       fetch-depth: 0
-  - name: PHP syntax checker 5.6
-    uses: dbfx/github-phplint/5.6@master
+  - name: PHP Lint 7.4
+    uses: dbfx/github-phplint/7.4@master
     with:
       folder-to-exclude: "! -path \"./vendor/*\" ! -path \"./folder/excluded/*\""
-  - name: PHP Lint 7.2
-    uses: dbfx/github-phplint/7.2@master
+  - name: PHP Lint 8.0
+    uses: dbfx/github-phplint/8.0@master
     with:
       folder-to-exclude: "! -path \"./vendor/*\" ! -path \"./folder/excluded/*\""
-  - name: PHP Lint 7.3
-    uses: dbfx/github-phplint/7.3@master
+  - name: PHP Lint 8.3
+    uses: dbfx/github-phplint/8.3@master
     with:
       folder-to-exclude: "! -path \"./vendor/*\" ! -path \"./folder/excluded/*\""
 ```
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: PHP Lint 7.2
@@ -59,10 +59,26 @@ jobs:
         uses: dbfx/github-phplint/7.3@master
         with:
           folder-to-exclude: "! -path \"./vendor/*\" ! -path \"./folder/excluded/*\""
-      - name: PHP Lint 5.6
-        uses: dbfx/github-phplint/5.6@master
+      - name: PHP Lint 7.4
+        uses: dbfx/github-phplint/7.4@master
+        with:
+          folder-to-exclude: "! -path \"./vendor/*\" ! -path \"./folder/excluded/*\""
+      - name: PHP Lint 8.0
+        uses: dbfx/github-phplint/8.0@master
         with:
           folder-to-exclude: "! -path \"./vendor/*\" ! -path \"./folder/excluded/*\""   
+      - name: PHP Lint 8.1
+        uses: dbfx/github-phplint/8.1@master
+        with:
+          folder-to-exclude: "! -path \"./vendor/*\" ! -path \"./folder/excluded/*\""
+      - name: PHP Lint 8.2
+        uses: dbfx/github-phplint/8.2@master
+        with:
+          folder-to-exclude: "! -path \"./vendor/*\" ! -path \"./folder/excluded/*\""
+      - name: PHP Lint 8.3
+        uses: dbfx/github-phplint/8.3@master
+        with:
+          folder-to-exclude: "! -path \"./vendor/*\" ! -path \"./folder/excluded/*\""
 ```
 
 If you want to run the lint on Pull Requests instead of pushes change the ```on: push``` to ```on: pull```.
@@ -80,7 +96,9 @@ Right now there is support for the following PHP versions:
  - 7.3
  - 7.4
  - 8.0
- - 8.1 
+ - 8.1
+ - 8.2
+ - 8.3
  
  If you would like to add more submit a PR or an issue. 
  


### PR DESCRIPTION
## Description:

* Added support for PHP 8.3.
  * Ran it on my own private repo and it worked as expected (see screenshot below)
* Updated the README file to utilize more recent PHP versions
  * Easier for users who just want to copy-paste something into their `.yml` file
* Updated the README file to utilize `actions/checkout@v4` to prevent GitHub warnings from bubbling up about `actions/checkout` using deprecated versions of node.js 

## Screenshots:

<img width="446" alt="image" src="https://github.com/dbfx/github-phplint/assets/8801299/73433e1b-9ff4-4754-8d47-2f7a110c90a8">
